### PR TITLE
NXBT-1671: use Dart SDK 1.23.*

### DIFF
--- a/roles/slave_tools/tasks/dart.yml
+++ b/roles/slave_tools/tasks/dart.yml
@@ -6,7 +6,7 @@
 - name: Update apt cache
   apt: update_cache=yes
 - name: Install Dart
-  apt: name=dart state=present
+  apt: name=dart=1.23.* state=present
 - name: Update alternatives
   alternatives: name={{item}} link=/usr/bin/{{item}} path=/usr/lib/dart/bin/{{item}}
   with_items:


### PR DESCRIPTION
Dart SDK 1.24 introduced changes that break the API Playground build...