### PR TITLE
NXBT-2873 lfs package is present in ubuntu repository since git 8.1

### DIFF
--- a/roles/slave_tools/files/git-lfs.list
+++ b/roles/slave_tools/files/git-lfs.list
@@ -1,2 +1,0 @@
-deb https://packagecloud.io/github/git-lfs/ubuntu/ bionic main
-

--- a/roles/slave_tools/tasks/git-lfs.yml
+++ b/roles/slave_tools/tasks/git-lfs.yml
@@ -1,11 +1,7 @@
 ---
-- name: Add git-lfs repo key
-  apt_key: url=https://packagecloud.io/gpg.key state=present
-- name: Add git-lfs repo
-  copy: src=git-lfs.list dest=/etc/apt/sources.list.d/git-lfs.list
 - name: Install git-lfs package
   apt:
     name=git-lfs
     state=present
-    update_cache=yes
+    update_cache=no
 


### PR DESCRIPTION
build failed on https://qa.nuxeo.org/jenkins/job/System/job/build-preprod-slave-images/217/ because of another error related to the s3 bucket migration