### PR TITLE
NXBT-2945: Install xclip for Nuxeo Drive tests

### DIFF
--- a/roles/slave_tools/tasks/main.yml
+++ b/roles/slave_tools/tasks/main.yml
@@ -116,6 +116,8 @@
   - python3-dev
   - python3-pip
   - python3-venv
+  # Nuxeo Drive stuff
+  - xclip
   tags: apt
 - name: Fix ImageMagick policy
   replace: dest=/etc/ImageMagick-6/policy.xml regexp='rights="none" pattern="(PS|EPS|PDF|XPS)"' replace='rights="read|write" pattern="\1"'


### PR DESCRIPTION
Since NXDRIVE-1780, Nuxeo Drive uses the system tool named xclip to copy/paste to/from the
clipboard.

As the feature is quite important and need tests to ensure it is working well, it is required to have GNU/Linux images that ship with that tool.