### PR TITLE
NXBT-3012: Install appstreamcli on the GNU/Linux agents

### DIFF
--- a/roles/slave_tools/tasks/main.yml
+++ b/roles/slave_tools/tasks/main.yml
@@ -118,6 +118,7 @@
   - python3-venv
   # Nuxeo Drive stuff
   - xclip
+  - appstreamcli
   tags: apt
 - name: Fix ImageMagick policy
   replace: dest=/etc/ImageMagick-6/policy.xml regexp='rights="none" pattern="(PS|EPS|PDF|XPS)"' replace='rights="read|write" pattern="\1"'


### PR DESCRIPTION
It is required to validate the AppImage conformity for Nuxeo Drive builds.