### PR TITLE
NXBT-3012: appstreamcli is part of the appstream package

### DIFF
--- a/roles/slave_tools/tasks/main.yml
+++ b/roles/slave_tools/tasks/main.yml
@@ -118,7 +118,7 @@
   - python3-venv
   # Nuxeo Drive stuff
   - xclip
-  - appstreamcli
+  - appstream
   tags: apt
 - name: Fix ImageMagick policy
   replace: dest=/etc/ImageMagick-6/policy.xml regexp='rights="none" pattern="(PS|EPS|PDF|XPS)"' replace='rights="read|write" pattern="\1"'


### PR DESCRIPTION
According to https://packages.ubuntu.com/bionic/appstream the `appstreamcli` binary is part of the `appstream` package.