### PR TITLE
NXBT-3369: Remove the appstream package from GNU/Linux agents

### DIFF
--- a/roles/slave_tools/tasks/main.yml
+++ b/roles/slave_tools/tasks/main.yml
@@ -118,7 +118,6 @@
   - python3-venv
   # Nuxeo Drive stuff
   - xclip
-  - appstream
   tags: apt
 - name: Fix ImageMagick policy
   replace: dest=/etc/ImageMagick-6/policy.xml regexp='rights="none" pattern="(PS|EPS|PDF|XPS)"' replace='rights="read|write" pattern="\1"'


### PR DESCRIPTION
With the move to Travis-CI, that package will never be used again.

Signed-off-by: Mickaël Schoentgen <mschoentgen@nuxeo.com>